### PR TITLE
Add include guard

### DIFF
--- a/data/books.json
+++ b/data/books.json
@@ -17,5 +17,9 @@
       "title": "Emma",
       "author": "Jane Austin"
     },
+    {
+      "title": "Ender's Game",
+      "author": "Orson Scott Card"
+    },
   ]
 }

--- a/data/colours.h
+++ b/data/colours.h
@@ -1,6 +1,8 @@
 /* Copyright (C) 2023 Analog Devices, Inc. */
 /* Some colours */
 
+#ifndef COLOURS_H
+
 #define RED 1
 #define ORANGE 2
 #define YELLOW 3
@@ -8,3 +10,5 @@
 #define BLUE 5
 #define INDIGO 6
 #define VIOLET 7
+
+#endif 


### PR DESCRIPTION
Avoid redefinition errors if the header file is included more than once.